### PR TITLE
Copy language grammar and snippet jsons to out for "vsce package"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 node_modules
+*.vsix

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,0 +1,20 @@
+// Gulpfile.js
+
+var gulp = require('gulp'),
+  del = require('del'),
+  changed = require('gulp-changed');
+
+gulp.task('clean', function (cb) {
+  del(["./out/src"], cb);
+});
+
+gulp.task('assets', function () {
+  var srcPath = "./src/**",
+    destPath = "./out/src"
+
+  return gulp.src(srcPath)
+    .pipe(changed(destPath))
+    .pipe(gulp.dest(destPath))
+});
+
+gulp.task('default', ['clean', 'assets']);

--- a/package.json
+++ b/package.json
@@ -1,42 +1,62 @@
 {
-	"name": "vscode-elixir",
-	"displayName": "vscode-elixir",
-	"description": "Elixir support for VSCode",
-	"keywords": ["Elixir", "syntax"],
-	"version": "0.0.6",
-	"publisher": "mjmcloug",
-	"icon": "images/logo.png",
-	"main": "./out/src/elixirMain",
-	"engines": {
-		"vscode": "^0.10.1"
-	},
-	"categories": [
-		"Languages"
-	],
-	"activationEvents": ["onLanguage:elixir"],
-	"contributes": {
-		"languages": [{
-			"id": "elixir",
-			"aliases": ["Elixir", "elixir"],
-			"extensions": [".ex",".exs"],
-			"configuration": "./src/elixir.configuration.json"
-		}],
-		"grammars": [{
-			"language": "elixir",
-			"scopeName": "source.elixir",
-			"path": "./src/syntaxes/elixir.tmLanguage"
-		}],
-		"snippets": [			{
-			"language": "elixir",
-			"path": "./src/snippets/snippets.json"
-		}]
-	},
-	"scripts": {
-		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
-	},
-	"devDependencies": {
-		"typescript": "^1.6.2",
-		"vscode": "0.10.x"
-	}
+  "name": "vscode-elixir",
+  "displayName": "vscode-elixir",
+  "description": "Elixir support for VSCode",
+  "keywords": [
+    "Elixir",
+    "syntax"
+  ],
+  "version": "0.0.6",
+  "publisher": "mjmcloug",
+  "icon": "images/logo.png",
+  "main": "./out/src/elixirMain",
+  "engines": {
+    "vscode": "^0.10.1"
+  },
+  "categories": [
+    "Languages"
+  ],
+  "activationEvents": [
+    "onLanguage:elixir"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "elixir",
+        "aliases": [
+          "Elixir",
+          "elixir"
+        ],
+        "extensions": [
+          ".ex",
+          ".exs"
+        ],
+        "configuration": "./out/src/elixir.configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "elixir",
+        "scopeName": "source.elixir",
+        "path": "./out/src/syntaxes/elixir.tmLanguage"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "elixir",
+        "path": "./out/src/snippets/snippets.json"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
+    "compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
+  },
+  "devDependencies": {
+    "del": "^2.2.0",
+    "gulp": "^3.9.1",
+    "gulp-changed": "^1.3.0",
+    "typescript": "^1.6.2",
+    "vscode": "0.10.x"
+  }
 }


### PR DESCRIPTION
#7
"vsce package" doesn't copy the grammar/snippet files to ./out. I have added gulp to copy these files over, and updated package.json to refer to the ./out/src/snippets and syntax files.