### PR TITLE
Add snippet for cond macro.

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,4 +1,10 @@
 {
+	"cond": {
+		"prefix": "cond",
+		"body": "cond do\n\t$1 ->\n\t\t$0\nend",
+		"description": "cond",
+		"scope": "source.elixir"
+	},
 	"def": {
 		"prefix": "def",
 		"body": "def $1 do\n\t$0\nend",


### PR DESCRIPTION
I added a new snippet for the cond macro to the top of the snippets file since it looked like it should be in alphabetical order, though the `test` macro is off.

Closes #15