### PR TITLE
Add snippet for do/end blocks

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -77,6 +77,12 @@
 		"description": "defstruct",
 		"scope": "source.elixir"
 	},
+	"do": {
+		"prefix": "do",
+		"body": "do\n\t$0\nend",
+		"descripton": "do/end block",
+		"scope": "source.elixir"
+	},
 	"doc": {
 		"prefix": "doc",
 		"body": "@doc \"\"\"\n$0\n\"\"\"",


### PR DESCRIPTION
This fixes that annoying issue with the `doc` snippet firing every time one tries to write a do/end block.

Fixes #12