### PR TITLE
[WIP] #21: highlight code blocks

### DIFF
--- a/src/elixirHighlightProvider.ts
+++ b/src/elixirHighlightProvider.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode';
+
+export class ElixirHighlightProvider implements vscode.DocumentHighlightProvider {
+
+  balancedPairs: BalancedPair[];
+
+  constructor() { }
+
+  provideDocumentHighlights(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.DocumentHighlight[] {
+    const result = this.balancedPairs.find(pair => (
+      pair.entry.start.line === position.line ||
+      pair.end.start.line === position.line));
+    if (result) {
+      return [new vscode.DocumentHighlight(result.entry, 2), new vscode.DocumentHighlight(result.end, 2)];
+    }
+  }
+
+  balanceEvent(event: vscode.TextEditor) {
+    if (event && event.document) {
+      this.balancePairs(event.document);
+    }
+  }
+
+  balancePairs(document: vscode.TextDocument) {
+    this.balancedPairs = [];
+    if (document.languageId !== 'elixir') {
+      return;
+    }
+    const waitingEntries: vscode.Range[] = [];
+    let entry: vscode.Range;
+    let end: vscode.Range;
+    for (let i = 0; i < document.lineCount; i++) {
+      if ((entry = this.getEntry(document.lineAt(i)))) {
+        waitingEntries.push(entry);
+      } else if (waitingEntries.length && (end = this.getEnd(document.lineAt(i)))) {
+        this.balancedPairs.push({
+          entry: waitingEntries.pop(),
+          end: end
+        });
+      }
+    }
+
+
+  }
+
+  getEntry(line: vscode.TextLine): vscode.Range {
+    let match = line.text.match(/^(?!.*do\:)(\s*)(def|defp|defmodule|defmacro|quote|case|cond|if|unless|try)\b.*$/);
+    if (match) {
+      return new vscode.Range(line.lineNumber, match[1].length, line.lineNumber, match[1].length + match[2].length);
+    } else {
+      match = line.text.match(/\b(do)\b\s*(\|.*\|[^;]*)?$/);
+      if (match) {
+        return new vscode.Range(line.lineNumber, match.index, line.lineNumber, match.index + 2);
+      } else {
+        match = line.text.match(/(?!.*do\:)\b(fn)\b.*$/);
+        if (match) {
+          return new vscode.Range(line.lineNumber, match.index, line.lineNumber, match.index + 2);
+        }
+      }
+    }
+  }
+
+  getEnd(line: vscode.TextLine): vscode.Range {
+    //end must be on a line by itself, or followed directly by a dot
+    const match = line.text.match(/^(\s*)end\b[\.\s#]?\s*$/);
+    if (match) {
+      return new vscode.Range(line.lineNumber, match[1].length, line.lineNumber, match[1].length + 3);
+    }
+
+  }
+
+}
+
+interface BalancedPair {
+  entry: vscode.Range;
+  end: vscode.Range;
+}

--- a/src/elixirMain.ts
+++ b/src/elixirMain.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { ElixirAutocomplete } from './elixirAutocomplete';
 import { ElixirServer } from './elixirServer';
 import { ElixirDefinitionProvider } from './elixirDefinitionProvider';
+import { ElixirHighlightProvider } from './elixirHighlightProvider';
 import {configuration} from './elixirConfiguration';
 
 const ELIXIR_MODE: vscode.DocumentFilter = { language: 'elixir', scheme: 'file' };
@@ -9,10 +10,19 @@ let elixirServer: ElixirServer;
 
 export function activate(ctx: vscode.ExtensionContext) {
     this.elixirServer = new ElixirServer();
+    const elixirHighlightProvider = new ElixirHighlightProvider();
     this.elixirServer.start();
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(ELIXIR_MODE, new ElixirAutocomplete(this.elixirServer)));
     ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(ELIXIR_MODE, new ElixirDefinitionProvider(this.elixirServer)));
     ctx.subscriptions.push(vscode.languages.setLanguageConfiguration('elixir', configuration));
+    ctx.subscriptions.push(vscode.languages.registerDocumentHighlightProvider('elixir', elixirHighlightProvider));
+    ctx.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(elixirHighlightProvider.balanceEvent.bind(elixirHighlightProvider)));
+    ctx.subscriptions.push(vscode.workspace.onDidChangeTextDocument(elixirHighlightProvider.balanceEvent.bind(elixirHighlightProvider)));
+    ctx.subscriptions.push(vscode.workspace.onDidOpenTextDocument(elixirHighlightProvider.balanceEvent.bind(elixirHighlightProvider)));
+    if (vscode.window && vscode.window.activeTextEditor) {
+        elixirHighlightProvider.balancePairs(vscode.window.activeTextEditor.document);
+    }
+
 }
 
 export function deactivate() {


### PR DESCRIPTION
Beginning working on highlighting code blocks.

This will close #21 

There are some 'edge' cases that currently are unsupported:

```elixir
  def call(%Plug.Conn{} = conn, []),
    do: conn # <- do: on next line after def
```
```elixir
  def clear_session(conn) do
    put_session(conn, fn(_existing) -> Map.new end) # end on same line as fn ->
  end
```
```elixir
def code(integer_or_atom) # function declaration w/o body
```
```elixir
  def call(conn, level) do
    Logger.log level, fn ->
      [conn.method, ?\s, conn.request_path]
    end

    start = current_time()

    Conn.register_before_send(conn, fn conn ->
      Logger.log level, fn ->
        stop = current_time()
        diff = time_diff(start, stop)

        [connection_type(conn), ?\s, Integer.to_string(conn.status),
         " in ", formatted_diff(diff)]
      end
      conn
    end) # <- 'end' with trailing ')'
  end
```

In my simple phoenix application it does work pretty well at the moment.
But I think before releasing this, those edge cases should be handled.