### PR TITLE
Add the current syntax highlighting from the official atom extension

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Textmate bundle for Elixir Programming Language.",
+  "comment": "Atom Syntax Parser for Elixir Programming Language.",
   "fileTypes": [
     "ex",
     "exs"
@@ -22,10 +22,10 @@
       "name": "meta.module.elixir"
     },
     {
-      "begin": "@(module|type)?doc (~[a-z])?\"\"\"",
-      "comment": "@doc with heredocs is treated as documentation",
+      "begin": "@(module|type)?doc (~s)?\"\"\"",
+      "comment": "@doc with interpolated heredocs",
       "end": "\\s*\"\"\"",
-      "name": "comment.documentation.heredoc",
+      "name": "comment.documentation.heredoc.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -36,10 +36,40 @@
       ]
     },
     {
-      "begin": "@(module|type)?doc ~[A-Z]\"\"\"",
+      "begin": "@(module|type)?doc ~s'''",
+      "comment": "@doc with interpolated single quoted heredocs",
+      "end": "\\s*'''",
+      "name": "comment.documentation.heredoc.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "@(module|type)?doc ~S\"\"\"",
       "comment": "@doc with heredocs is treated as documentation",
       "end": "\\s*\"\"\"",
-      "name": "comment.documentation.heredoc"
+      "name": "comment.documentation.heredoc.elixir",
+      "patterns": [
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "@(module|type)?doc ~S'''",
+      "comment": "@doc with heredocs is treated as documentation",
+      "end": "\\s*'''",
+      "name": "comment.documentation.heredoc.elixir",
+      "patterns": [
+        {
+          "include": "#escaped_char"
+        }
+      ]
     },
     {
       "comment": "@doc false is treated as documentation",
@@ -63,6 +93,16 @@
     {
       "match": "(?<!\\.)\\b(alias|require|import|use)\\b(?![?!])",
       "name": "keyword.other.special-method.elixir"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.elixir"
+        }
+      },
+      "comment": "symbols",
+      "match": "(?>[a-zA-Z_][\\w@]*(?>[?!])?)(:)(?!:)",
+      "name": "constant.other.symbol.elixir"
     },
     {
       "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecord|defstruct|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when)\\b(?![?!])",
@@ -94,30 +134,1697 @@
       "name": "variable.language.elixir"
     },
     {
-      "captures": {
-        "1": {
-          "name": "punctuation.definition.variable.elixir"
-        }
-      },
-      "match": "(@)[a-zA-Z_]\\w*",
-      "name": "variable.other.readwrite.module.elixir"
-    },
-    {
-      "captures": {
-        "1": {
-          "name": "punctuation.definition.variable.elixir"
-        }
-      },
-      "match": "(&)\\d*",
-      "name": "variable.other.anonymous.elixir"
-    },
-    {
       "match": "\\b[A-Z]\\w*\\b",
       "name": "variable.other.constant.elixir"
     },
     {
       "match": "\\b(0[xX]\\h(?>_?\\h)*|\\d(?>_?\\d)*(\\.(?![^[:space:][:digit:]])(?>_?\\d)*)?([eE][-+]?\\d(?>_?\\d)*)?|0[bB][01]+)\\b",
       "name": "constant.numeric.elixir"
+    },
+    {
+      "comment": "Regex sigil with curlies",
+      "begin": "~r\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\}[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_curly"
+        }
+      ]
+    },
+    {
+      "comment": "Regex sigil with pipes",
+      "begin": "~r\\|",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\|[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        }
+      ]
+    },
+    {
+      "comment": "Regex sigil with parens",
+      "begin": "~r\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\)[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        }
+      ]
+    },
+    {
+      "comment": "Regex sigil with slashes",
+      "begin": "~r\\/",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\/[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        }
+      ]
+    },
+    {
+      "comment": "Regex sigil with brackets",
+      "begin": "~r\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\][eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    {
+      "comment": "Regex sigil with ltgt",
+      "begin": "~r\\<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\>[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "comment": "Regex sigil with single quoted heredocs",
+      "begin": "~r\\'\\'\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\'\\'\\'[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "comment": "Regex sigil with single quotes",
+      "begin": "~r\\\"\\\"\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\\"\\\"\\\"[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "comment": "Regex sigil with double quotes",
+      "begin": "~r\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\\"[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "comment": "Regex sigil with single quotes",
+      "begin": "~r\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\'[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#regex_sub"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "comment": "Literal regex sigil with curlies",
+      "begin": "~R\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\}[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_curly"
+        }
+      ]
+    },
+    {
+      "comment": "Literal regex sigil with pipes",
+      "begin": "~R\\|",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\|[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.literal.elixir"
+    },
+    {
+      "comment": "Literal regex sigil with parens",
+      "begin": "~R\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\)[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_parens"
+        }
+      ]
+    },
+    {
+      "comment": "Literal regex sigil with slashes",
+      "begin": "~R\\/",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\/[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.literal.elixir"
+    },
+    {
+      "comment": "Literal regex sigil with brackets",
+      "begin": "~R\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\][eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    {
+      "comment": "Literal regex sigil with ltgt",
+      "begin": "~R\\<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\>[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "comment": "Literal regex sigil with single quoted heredoc",
+      "begin": "~R\\'\\'\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\'\\'\\'[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "comment": "Literal regex sigil with double quoted heredoc",
+      "begin": "~R\\\"\\\"\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\\"\\\"\\\"[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "comment": "Literal regex sigil with double quotes",
+      "begin": "~R\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\\"[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "comment": "Literal regex sigil with single quotes",
+      "begin": "~R\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.begin.elixir"
+        }
+      },
+      "end": "\\'[eimnosux]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.regexp.end.elixir"
+        }
+      },
+      "name": "string.regexp.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "comment": "Character list sigil with curlies",
+      "begin": "~c\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\}[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Character list sigil with pipes",
+      "begin": "~c\\|",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\|[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Character list sigil with parens",
+      "begin": "~c\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\)[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Character list sigil with curlies",
+      "begin": "~c\\<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\>[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Character list sigil with curlies",
+      "begin": "~c\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\][a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Character list sigil with curlies",
+      "begin": "~c\\/",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\/[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Character list sigil with single quoted heredoc",
+      "begin": "~c\\'\\'\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\'\\'\\'[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Character list sigil with double quoted heredoc",
+      "begin": "~c\\\"\\\"\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\\"\\\"\\\"[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Character list sigil with curlies",
+      "begin": "~c\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\'[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Character list sigil with curlies",
+      "begin": "~c\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\\"[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Literal Character list sigil with curlies",
+      "begin": "~C\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\}[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir"
+    },
+    {
+      "comment": "Literal Character list sigil with pipes",
+      "begin": "~C\\|",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\|[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir"
+    },
+    {
+      "comment": "Literal Character list sigil with parens",
+      "begin": "~C\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\)[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir"
+    },
+    {
+      "comment": "Literal Character list sigil with curlies",
+      "begin": "~C\\<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\>[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir"
+    },
+    {
+      "comment": "Literal Character list sigil with curlies",
+      "begin": "~C\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\][a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir"
+    },
+    {
+      "comment": "Literal Character list sigil with curlies",
+      "begin": "~C\\/",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\/[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir"
+    },
+    {
+      "comment": "Literal Character list sigil with single quoted heredoc",
+      "begin": "~C\\'\\'\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\'\\'\\'[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir"
+    },
+    {
+      "comment": "Literal Character list sigil with double quoted heredoc",
+      "begin": "~C\\\"\\\"\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\\"\\\"\\\"[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir"
+    },
+    {
+      "comment": "Literal Character list sigil with curlies",
+      "begin": "~C\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\'[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir"
+    },
+    {
+      "comment": "Literal Character list sigil with curlies",
+      "begin": "~C\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "end": "\\\"[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "support.function.variable.quoted.single.elixir"
+    },
+    {
+      "begin": "~w\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\}[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_curly"
+        }
+      ]
+    },
+    {
+      "begin": "~w\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\][acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    {
+      "begin": "~w\\<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\>[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "begin": "~w\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\)[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_parens"
+        }
+      ]
+    },
+    {
+      "begin": "~w\\/",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\/[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "~w\\|",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\|[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Interpolated word list sigil with single quoted heredoc",
+      "begin": "~w\\'\\'\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "end": "\\'\\'\\'[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "comment": "Interpolated word list sigil with double quoted heredoc",
+      "begin": "~w\\\"\\\"\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "end": "\\\"\\\"\\\"[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "~w\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\'[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "~w\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\\"[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "~W\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\}[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir"
+    },
+    {
+      "begin": "~W\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\][acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    {
+      "begin": "~W\\<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\>[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "begin": "~W\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\)[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_parens"
+        }
+      ]
+    },
+    {
+      "begin": "~W\\/",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\/[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir"
+    },
+    {
+      "begin": "~W\\|",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\|[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir"
+    },
+    {
+      "comment": "Literal word list sigil with single quoted heredoc",
+      "begin": "~W\\'\\'\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "end": "\\'\\'\\'[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir"
+    },
+    {
+      "comment": "Literal word list sigil with double quoted heredoc",
+      "begin": "~W\\\"\\\"\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "end": "\\\"\\\"\\\"[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir"
+    },
+    {
+      "begin": "~W\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\'[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir"
+    },
+    {
+      "begin": "~W\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.list.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\\"[acs]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.list.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir"
+    },
+    {
+      "begin": "~[a-z](?>\"\"\")",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "Double-quoted heredocs sigils",
+      "end": "^\\s*\"\"\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.heredoc.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "~[a-z](?>''')",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "Double-quoted heredocs sigils",
+      "end": "^\\s*'''",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.heredoc.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "~[a-z]\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\}[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_curly"
+        }
+      ]
+    },
+    {
+      "begin": "~[a-z]\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\][a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    {
+      "begin": "~[a-z]\\<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\>[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "begin": "~[a-z]\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\)[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        },
+        {
+          "include": "#nest_parens"
+        }
+      ]
+    },
+    {
+      "begin": "~[a-z]\\/",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\/[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "~[a-z]\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\'[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "~[a-z]\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\\"[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "~[a-z]\\|",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (allow for interpolation)",
+      "end": "\\|[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.interpolated.elixir",
+      "patterns": [
+        {
+          "include": "#interpolated_elixir"
+        },
+        {
+          "include": "#escaped_char"
+        }
+      ]
+    },
+    {
+      "begin": "~[A-Z](?>\"\"\")",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "Double-quoted heredocs sigils",
+      "end": "^\\s*\"\"\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.other.literal.elixir"
+    },
+    {
+      "begin": "~[A-Z](?>''')",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "Double-quoted heredocs sigils",
+      "end": "^\\s*'''",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.other.literal.elixir"
+    },
+    {
+      "begin": "~[A-Z]\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\}[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir"
+    },
+    {
+      "begin": "~[A-Z]\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\][a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_brackets"
+        }
+      ]
+    },
+    {
+      "begin": "~[A-Z]\\<",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\>[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_ltgt"
+        }
+      ]
+    },
+    {
+      "begin": "~[A-Z]\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\)[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir",
+      "patterns": [
+        {
+          "include": "#nest_parens"
+        }
+      ]
+    },
+    {
+      "begin": "~[A-Z]\\/",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\/[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir"
+    },
+    {
+      "begin": "~[A-Z]\\'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\'[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir"
+    },
+    {
+      "begin": "~[A-Z]\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\\"[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir"
+    },
+    {
+      "begin": "~[A-Z]\\|",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.elixir"
+        }
+      },
+      "comment": "sigil (without interpolation)",
+      "end": "\\|[a-z]*",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.elixir"
+        }
+      },
+      "name": "string.quoted.double.literal.elixir"
     },
     {
       "begin": ":'",
@@ -252,308 +1959,22 @@
       ]
     },
     {
-      "begin": "~[a-z](?>\"\"\")",
+      "begin": "#",
       "beginCaptures": {
         "0": {
-          "name": "punctuation.definition.string.begin.elixir"
-        }
-      },
-      "comment": "Double-quoted heredocs sigils",
-      "end": "^\\s*\"\"\"",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.elixir"
-        }
-      },
-      "name": "string.quoted.double.heredoc.elixir",
-      "patterns": [
-        {
-          "include": "#interpolated_elixir"
-        },
-        {
-          "include": "#escaped_char"
-        }
-      ]
-    },
-    {
-      "begin": "~[a-z]\\{",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.elixir"
-        }
-      },
-      "comment": "sigil (allow for interpolation)",
-      "end": "\\}[a-z]*",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.elixir"
-        }
-      },
-      "name": "string.interpolated.elixir",
-      "patterns": [
-        {
-          "include": "#interpolated_elixir"
-        },
-        {
-          "include": "#escaped_char"
-        },
-        {
-          "include": "#nest_curly"
-        }
-      ]
-    },
-    {
-      "begin": "~[a-z]\\[",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.elixir"
-        }
-      },
-      "comment": "sigil (allow for interpolation)",
-      "end": "\\][a-z]*",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.elixir"
-        }
-      },
-      "name": "string.interpolated.elixir",
-      "patterns": [
-        {
-          "include": "#interpolated_elixir"
-        },
-        {
-          "include": "#escaped_char"
-        },
-        {
-          "include": "#nest_brackets"
-        }
-      ]
-    },
-    {
-      "begin": "~[a-z]\\<",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.elixir"
-        }
-      },
-      "comment": "sigil (allow for interpolation)",
-      "end": "\\>[a-z]*",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.elixir"
-        }
-      },
-      "name": "string.interpolated.elixir",
-      "patterns": [
-        {
-          "include": "#interpolated_elixir"
-        },
-        {
-          "include": "#escaped_char"
-        },
-        {
-          "include": "#nest_ltgt"
-        }
-      ]
-    },
-    {
-      "begin": "~[a-z]\\(",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.elixir"
-        }
-      },
-      "comment": "sigil (allow for interpolation)",
-      "end": "\\)[a-z]*",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.elixir"
-        }
-      },
-      "name": "string.interpolated.elixir",
-      "patterns": [
-        {
-          "include": "#interpolated_elixir"
-        },
-        {
-          "include": "#escaped_char"
-        },
-        {
-          "include": "#nest_parens"
-        }
-      ]
-    },
-    {
-      "begin": "~[a-z]([^\\w])",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.elixir"
-        }
-      },
-      "comment": "sigil (allow for interpolation)",
-      "end": "\\1[a-z]*",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.elixir"
-        }
-      },
-      "name": "string.interpolated.elixir",
-      "patterns": [
-        {
-          "include": "#interpolated_elixir"
-        },
-        {
-          "include": "#escaped_char"
-        },
-        {
-          "include": "#escaped_char"
-        }
-      ]
-    },
-    {
-      "begin": "~[A-Z](?>\"\"\")",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.elixir"
-        }
-      },
-      "comment": "Double-quoted heredocs sigils",
-      "end": "^\\s*\"\"\"",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.elixir"
-        }
-      },
-      "name": "string.quoted.other.literal.upper.elixir"
-    },
-    {
-      "begin": "~[A-Z]\\{",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.elixir"
-        }
-      },
-      "comment": "sigil (without interpolation)",
-      "end": "\\}[a-z]*",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.elixir"
-        }
-      },
-      "name": "string.quoted.other.literal.upper.elixir",
-      "patterns": [
-        {
-          "include": "#nest_curly"
-        }
-      ]
-    },
-    {
-      "begin": "~[A-Z]\\[",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.elixir"
-        }
-      },
-      "comment": "sigil (without interpolation)",
-      "end": "\\][a-z]*",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.elixir"
-        }
-      },
-      "name": "string.quoted.other.literal.upper.elixir",
-      "patterns": [
-        {
-          "include": "#nest_brackets"
-        }
-      ]
-    },
-    {
-      "begin": "~[A-Z]\\<",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.elixir"
-        }
-      },
-      "comment": "sigil (without interpolation)",
-      "end": "\\>[a-z]*",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.elixir"
-        }
-      },
-      "name": "string.quoted.other.literal.upper.elixir",
-      "patterns": [
-        {
-          "include": "#nest_ltgt"
-        }
-      ]
-    },
-    {
-      "begin": "~[A-Z]\\(",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.elixir"
-        }
-      },
-      "comment": "sigil (without interpolation)",
-      "end": "\\)[a-z]*",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.elixir"
-        }
-      },
-      "name": "string.quoted.other.literal.upper.elixir",
-      "patterns": [
-        {
-          "include": "#nest_parens"
-        }
-      ]
-    },
-    {
-      "begin": "~[A-Z]([^\\w])",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.elixir"
-        }
-      },
-      "comment": "sigil (without interpolation)",
-      "end": "\\1[a-z]*",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.elixir"
-        }
-      },
-      "name": "string.quoted.other.literal.upper.elixir"
-    },
-    {
-      "captures": {
-        "1": {
-          "name": "punctuation.definition.constant.elixir"
-        }
-      },
-      "comment": "symbols",
-      "match": "(?<!:)(:)(?>[a-zA-Z_][\\w@]*(?>[?!]|=(?![>=]))?|\\<\\>|===?|!==?|<<>>|<<<|>>>|~~~|::|<\\-|\\|>|=>|~|~=|=|/|\\\\\\\\|\\*\\*?|\\.\\.?\\.?|>=?|<=?|&&?&?|\\+\\+?|\\-\\-?|\\|\\|?\\|?|\\!|@|\\%?\\{\\}|%|\\[\\]|\\^(\\^\\^)?)",
-      "name": "constant.other.symbol.elixir"
-    },
-    {
-      "captures": {
-        "1": {
-          "name": "punctuation.definition.constant.elixir"
-        }
-      },
-      "comment": "symbols",
-      "match": "(?>[a-zA-Z_][\\w@]*(?>[?!])?)(:)(?!:)",
-      "name": "constant.other.symbol.elixir"
-    },
-    {
-      "captures": {
-        "1": {
           "name": "punctuation.definition.comment.elixir"
         }
       },
-      "match": "(?:^[ \\t]+)?(#).*$\\n?",
+      "end": "\\n",
       "name": "comment.line.number-sign.elixir"
+    },
+    {
+      "match": "\\b_([\\w]+[?!]?)",
+      "name": "unused.comment.elixir"
+    },
+    {
+      "match": "\\b_\\b",
+      "name": "wildcard.comment.elixir"
     },
     {
       "comment": "matches questionmark-letters.\n\nexamples (1st alternation = hex):\n?\\x1     ?\\x61\n\nexamples (2nd alternation = octal):\n?\\0      ?\\07     ?\\017\n\nexamples (3rd alternation = escaped):\n?\\n      ?\\b\n\nexamples (4th alternation = meta-ctrl):\n?\\C-a    ?\\M-a    ?\\C-\\M-\\C-\\M-a\n\nexamples (4th alternation = normal):\n?a       ?A       ?0\n?*       ?\"       ?(\n?.       ?#\n\n\nthe negative lookbehind prevents against matching\np(42.tainted?)",
@@ -561,40 +1982,17 @@
       "name": "constant.numeric.elixir"
     },
     {
-      "begin": "(?<=\\{|do|\\{\\s|do\\s)(\\|)",
-      "captures": {
-        "1": {
-          "name": "punctuation.separator.variable.elixir"
-        }
-      },
-      "end": "(\\|)",
-      "patterns": [
-        {
-          "match": "[_a-zA-Z][_a-zA-Z0-9]*",
-          "name": "variable.other.block.elixir"
-        },
-        {
-          "match": ",",
-          "name": "punctuation.separator.variable.elixir"
-        }
-      ]
+      "match": "(\\|\\|\\||&&&|\\^\\^\\^|<<<|>>>|~~~)",
+      "name": "keyword.operator.bitwise.elixir"
     },
     {
-      "comment": "matches: | ++ -- ** \\ <- <> << >> :: .. |> ~ => ->",
-      "match": "\\+\\+|\\-\\-|\\*\\*|\\\\\\\\|\\<\\-|\\<\\>|\\<\\<|\\>\\>|\\:\\:|\\.\\.|\\|>|~|=>|->|\\|",
+      "comment": "matches: | ++ -- ** \\ <- <> << >> :: .. |> => -> <|> <~> <~ <<~ ~> ~>>",
+      "match": "\\+\\+|\\-\\-|\\*\\*|\\\\\\\\|\\<\\-|<\\<\\~|\\<\\>|\\<\\<|\\>\\>|\\:\\:|\\.\\.|\\|>|=>|<\\|\\>|<~>|->|~>>|~>|<~",
       "name": "keyword.operator.other.elixir"
     },
     {
-      "match": "\\+=|\\-=|\\|\\|=|~=|&&=",
-      "name": "keyword.operator.assignment.augmented.elixir"
-    },
-    {
-      "match": "===?|!==?|<=?|>=?",
+      "match": "===?|!==?|<=?|>=?|=~",
       "name": "keyword.operator.comparison.elixir"
-    },
-    {
-      "match": "(\\|\\|\\||&&&|\\^\\^\\^|<<<|>>>|~~~)",
-      "name": "keyword.operator.bitwise.elixir"
     },
     {
       "match": "(?<=[ \\t])!+|\\bnot\\b|&&|\\band\\b|\\|\\||\\bor\\b|\\bxor\\b",
@@ -607,10 +2005,6 @@
     {
       "match": "=",
       "name": "keyword.operator.assignment.elixir"
-    },
-    {
-      "match": ":",
-      "name": "punctuation.separator.other.elixir"
     },
     {
       "match": "\\;",
@@ -629,12 +2023,44 @@
       "name": "punctuation.section.scope.elixir"
     },
     {
-      "match": "\\[|\\]",
+      "match": "\\[\\]|\\[|\\]",
       "name": "punctuation.section.array.elixir"
     },
     {
       "match": "\\(|\\)",
       "name": "punctuation.section.function.elixir"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.variable.elixir"
+        }
+      },
+      "match": "(@)[a-zA-Z_]\\w*",
+      "name": "variable.other.readwrite.module.elixir"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.variable.elixir"
+        }
+      },
+      "match": "(&)\\d*",
+      "name": "variable.other.anonymous.elixir"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.elixir"
+        }
+      },
+      "comment": "symbols",
+      "match": "(?<!:)(:)(?>[a-zA-Z_][\\w@]*(?>[?!]|=(?![>=]))?|\\<\\>|===?|!==?|<<>>|<<<|>>>|~~~|::|<\\-|\\|>|=>|~|~=|=|/|\\\\\\\\|\\*\\*?|\\.\\.?\\.?|>=?|<=?|&&?&?|\\+\\+?|\\-\\-?|\\|\\|?\\|?|\\!|@|\\%?\\{\\}|%|\\[\\]|\\^(\\^\\^)?)",
+      "name": "constant.other.symbol.elixir"
+    },
+    {
+      "match": ":",
+      "name": "punctuation.separator.other.elixir"
     }
   ],
   "repository": {
@@ -754,6 +2180,7 @@
       ]
     },
     "regex_sub": {
+      "name": "string.interpolated.regexp.elixir",
       "patterns": [
         {
           "include": "#interpolated_elixir"
@@ -762,6 +2189,8 @@
           "include": "#escaped_char"
         },
         {
+          "name": "string.regexp.arbitrary-repitition.elixir",
+          "match": "(\\{)\\d+(,\\d+)?(\\})",
           "captures": {
             "1": {
               "name": "punctuation.definition.arbitrary-repitition.elixir"
@@ -769,19 +2198,17 @@
             "3": {
               "name": "punctuation.definition.arbitrary-repitition.elixir"
             }
-          },
-          "match": "(\\{)\\d+(,\\d+)?(\\})",
-          "name": "string.regexp.arbitrary-repitition.elixir"
+          }
         },
         {
+          "name": "string.regexp.character-class.elixir",
           "begin": "\\[(?:\\^?\\])?",
+          "end": "\\]",
           "captures": {
             "0": {
               "name": "punctuation.definition.character-class.elixir"
             }
           },
-          "end": "\\]",
-          "name": "string.regexp.character-class.elixir",
           "patterns": [
             {
               "include": "#escaped_char"
@@ -804,13 +2231,19 @@
           ]
         },
         {
-          "captures": {
+          "begin": "(?<=^|\\s)(#)\\s(?=[[a-zA-Z0-9,. \\t?!-][^\\x{00}-\\x{7F}]]*$)",
+          "beginCaptures": {
             "1": {
               "name": "punctuation.definition.comment.elixir"
             }
           },
           "comment": "We are restrictive in what we allow to go after the comment character to avoid false positives, since the availability of comments depend on regexp flags.",
-          "match": "(?<=^|\\s)(#)\\s[[a-zA-Z0-9,. \\t?!-][^\\x{00}-\\x{7F}]]*$",
+          "end": "$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.elixir"
+            }
+          },
           "name": "comment.line.number-sign.elixir"
         }
       ]


### PR DESCRIPTION
This adds better and a more up to date syntax highlighting.

It is recommended to use a different syntax theme then the default VS Code.